### PR TITLE
Allow SNI to be forced for an SSL connection

### DIFF
--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -254,6 +254,9 @@ QNetworkReply *NetworkAccessManager::createRequest(Operation op, const QNetworkR
     JsNetworkRequest jsNetworkRequest(&req, this);
     emit resourceRequested(data, &jsNetworkRequest);
 
+    m_sslConfiguration.setSniHostName(req.rawHeader("Host"));
+    req.setSslConfiguration(m_sslConfiguration);
+
     // Pass duty to the superclass - Nothing special to do here (yet?)
     QNetworkReply *reply = QNetworkAccessManager::createRequest(op, req, outgoingData);
 

--- a/src/qt/src/network/access/qhttpnetworkconnectionchannel.cpp
+++ b/src/qt/src/network/access/qhttpnetworkconnectionchannel.cpp
@@ -604,7 +604,12 @@ bool QHttpNetworkConnectionChannel::ensureConnection()
         if (ssl) {
 #ifndef QT_NO_OPENSSL
             QSslSocket *sslSocket = qobject_cast<QSslSocket*>(socket);
-            sslSocket->connectToHostEncrypted(connectHost, connectPort);
+            QString sniHostName = sslSocket->sslConfiguration().sniHostName();
+            if (sniHostName.isNull()) {
+                sslSocket->connectToHostEncrypted(connectHost, connectPort);
+            } else {
+                sslSocket->connectToHostEncrypted(connectHost, connectPort, sniHostName);
+            }
             if (ignoreAllSslErrors)
                 sslSocket->ignoreSslErrors();
             sslSocket->ignoreSslErrors(ignoreSslErrorsList);

--- a/src/qt/src/network/ssl/qsslconfiguration.cpp
+++ b/src/qt/src/network/ssl/qsslconfiguration.cpp
@@ -168,6 +168,7 @@ bool QSslConfiguration::operator==(const QSslConfiguration &other) const
         d->protocol == other.d->protocol &&
         d->peerVerifyMode == other.d->peerVerifyMode &&
         d->peerVerifyDepth == other.d->peerVerifyDepth &&
+        d->sniHostName == other.d->sniHostName &&
         d->sslOptions == other.d->sslOptions;
 }
 
@@ -201,6 +202,7 @@ bool QSslConfiguration::isNull() const
             d->privateKey.isNull() &&
             d->peerCertificate.isNull() &&
             d->peerCertificateChain.count() == 0 &&
+            d->sniHostName.isNull() &&
             d->sslOptions == ( QSsl::SslOptionDisableEmptyFragments
                               |QSsl::SslOptionDisableLegacyRenegotiation
                               |QSsl::SslOptionDisableCompression));
@@ -508,6 +510,16 @@ QList<QSslCertificate> QSslConfiguration::caCertificates() const
 void QSslConfiguration::setCaCertificates(const QList<QSslCertificate> &certificates)
 {
     d->caCertificates = certificates;
+}
+
+QString QSslConfiguration::sniHostName() const
+{
+    return d->sniHostName;
+}
+
+void QSslConfiguration::setSniHostName(const QString &hostName)
+{
+    d->sniHostName = hostName;
 }
 
 /*!

--- a/src/qt/src/network/ssl/qsslconfiguration.h
+++ b/src/qt/src/network/ssl/qsslconfiguration.h
@@ -119,6 +119,10 @@ public:
     QList<QSslCertificate> caCertificates() const;
     void setCaCertificates(const QList<QSslCertificate> &certificates);
 
+    // Override host name for SNI
+    QString sniHostName() const;
+    void setSniHostName(const QString &hostName);
+
     void setSslOption(QSsl::SslOption option, bool on);
     bool testSslOption(QSsl::SslOption option) const;
 

--- a/src/qt/src/network/ssl/qsslconfiguration_p.h
+++ b/src/qt/src/network/ssl/qsslconfiguration_p.h
@@ -101,6 +101,8 @@ public:
     QSslSocket::PeerVerifyMode peerVerifyMode;
     int peerVerifyDepth;
 
+    QString sniHostName;
+
     QSsl::SslOptions sslOptions;
 
     // in qsslsocket.cpp:

--- a/src/qt/src/network/ssl/qsslsocket.cpp
+++ b/src/qt/src/network/ssl/qsslsocket.cpp
@@ -897,6 +897,7 @@ void QSslSocket::setSslConfiguration(const QSslConfiguration &configuration)
     d->configuration.peerVerifyMode = configuration.peerVerifyMode();
     d->configuration.protocol = configuration.protocol();
     d->configuration.sslOptions = configuration.d->sslOptions;
+    d->configuration.sniHostName = configuration.d->sniHostName;
     d->allowRootCertOnDemandLoading = false;
 }
 

--- a/test/webpage-spec.js
+++ b/test/webpage-spec.js
@@ -1307,6 +1307,28 @@ describe("WebPage object", function() {
             server.close();
         });
     });
+
+    it('should succeed on secure connection to IP address using host name header', function() {
+        var page = require('webpage').create();
+        var url = 'https://www.cloudflare.com';
+        var target = 'https://173.245.56.11';
+        var loaded = false;
+
+        runs(function() {
+            page.onResourceRequested = function(request, jsNetworkRequest) {
+                if (request.url.indexOf(target) == 0) {
+                    jsNetworkRequest.changeUrl(request.url.replace(url, target))
+                    jsNetworkRequest.setHeader('Host', 'www.cloudflare.com');
+                }
+            };
+            page.open(url, function(status) {
+                expect(status).toEqual('success');
+                loaded = true;
+            });
+        });
+
+        waitsFor(function() { return loaded; }, 'Can not load ' + url, 5000);
+    });
 });
 
 describe("WebPage construction with options", function () {


### PR DESCRIPTION
Using QSslConfiguration::setSniHostName(QString), the socket using
that configuration will use SNI with the given hostname.

N.B. the new test requires phantomjs run with the arguments:
--ignore-ssl-errors=true --ssl-protocol='tlsv1'