### PR TITLE
Use secure TLS protocols by default

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -66,7 +66,7 @@ static const struct QCommandLineConfigEntry flags[] =
     { QCommandLine::Option, '\0', "proxy-type", "Specifies the proxy type, 'http' (default), 'none' (disable completely), or 'socks5'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "script-encoding", "Sets the encoding used for the starting script, default is 'utf8'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "web-security", "Enables web security, 'true' (default) or 'false'", QCommandLine::Optional },
-    { QCommandLine::Option, '\0', "ssl-protocol", "Sets the SSL protocol (supported protocols: 'SSLv3' (default), 'SSLv2', 'TLSv1', 'TLSv1.1', 'TLSv1.2', 'any')", QCommandLine::Optional },
+    { QCommandLine::Option, '\0', "ssl-protocol", "Sets the SSL protocol (supported protocols: 'secure' (default), 'SSLv3', 'SSLv2', 'TLSv1', 'TLSv1.1', 'TLSv1.2', 'any')", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "ssl-certificates-path", "Sets the location for custom CA certificates (if none set, uses system default)", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "webdriver", "Starts in 'Remote WebDriver mode' (embedded GhostDriver): '[[<IP>:]<PORT>]' (default '127.0.0.1:8910') ", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "webdriver-logfile", "File where to write the WebDriver's Log (default 'none') (NOTE: needs '--webdriver') ", QCommandLine::Optional },
@@ -539,7 +539,7 @@ void Config::resetToDefaults()
     m_javascriptCanCloseWindows = true;
     m_helpFlag = false;
     m_printDebugMessages = false;
-    m_sslProtocol = "sslv3";
+    m_sslProtocol = "secure";
     m_sslCertificatesPath.clear();
     m_webdriverIp = QString();
     m_webdriverPort = QString();

--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -137,11 +137,13 @@ NetworkAccessManager::NetworkAccessManager(QObject *parent, const Config *config
             m_sslConfiguration.setPeerVerifyMode(QSslSocket::VerifyNone);
         }
 
-        // set the SSL protocol to SSLv3 by the default
-        m_sslConfiguration.setProtocol(QSsl::SslV3);
+        // set the SSL protocol to SSLv3 or newer by default
+        m_sslConfiguration.setProtocol(QSsl::SecureProtocols);
 
         if (config->sslProtocol() == "sslv2") {
             m_sslConfiguration.setProtocol(QSsl::SslV2);
+        } else if (config->sslProtocol() == "sslv3") {
+            m_sslConfiguration.setProtocol(QSsl::SslV3);
         } else if (config->sslProtocol() == "tlsv1") {
             m_sslConfiguration.setProtocol(QSsl::TlsV1);
         } else if (config->sslProtocol() == "tlsv1.1") {

--- a/src/qt/src/network/ssl/qsslsocket_openssl.cpp
+++ b/src/qt/src/network/ssl/qsslsocket_openssl.cpp
@@ -268,7 +268,7 @@ init_context:
     case QSsl::SslV3:
         ctx = q_SSL_CTX_new(client ? q_SSLv3_client_method() : q_SSLv3_server_method());
         break;
-    case QSsl::SecureProtocols: // SslV2 will be disabled below
+    case QSsl::SecureProtocols: // SslV2 & V3 will be disabled below
     case QSsl::TlsV1SslV3: // SslV2 will be disabled below
     case QSsl::AnyProtocol:
     default:
@@ -310,8 +310,10 @@ init_context:
 
     // Enable bug workarounds.
     long options;
-    if (configuration.protocol == QSsl::TlsV1SslV3 || configuration.protocol == QSsl::SecureProtocols)
+    if (configuration.protocol == QSsl::TlsV1SslV3)
         options = SSL_OP_ALL|SSL_OP_NO_SSLv2;
+    else if (configuration.protocol == QSsl::SecureProtocols)
+        options = SSL_OP_ALL|SSL_OP_NO_SSLv2|SSL_OP_NO_SSLv3;
     else
         options = SSL_OP_ALL;
 


### PR DESCRIPTION
When a specific SSL protocol is set, it's not possible to negotiate the TLS version with the server. This makes it impossible to fetch resources from two separate servers that support different, non-intersecting versions (e.g. TLS v1.0 and TLS v1.2).

We should negotiate the protocol by default, as openssl s_client, curl and other tools do.